### PR TITLE
CypherWriter escapes backslashes and single quotes in strings.

### DIFF
--- a/src/main/java/iot/jcypher/query/writer/CypherWriter.java
+++ b/src/main/java/iot/jcypher/query/writer/CypherWriter.java
@@ -1217,8 +1217,10 @@ public class CypherWriter {
 				pval = pval == null ? "NOT_SET" : pval;
 				PrimitiveCypherWriter.writePrimitiveValue(pval, context, sb);
 			} else {
+				String str = val.toString();
+				String escaped = str.replace("\\", "\\\\").replace("'", "\\'");
 				sb.append('\'');
-				sb.append(val.toString());
+				sb.append(escaped);
 				sb.append('\'');
 			}
 		}


### PR DESCRIPTION
Strings are passed as single quoted strings into cypher queries. If I pass it a String value like `'s Hertogenbosch` it breaks the query. The special character `\` should also be escaped in Strings.
This PR fixes that. 