### PR TITLE
problem with the result table structure

### DIFF
--- a/src/main/java/iot/jcypher/query/result/util/ResultHandler.java
+++ b/src/main/java/iot/jcypher/query/result/util/ResultHandler.java
@@ -246,8 +246,7 @@ public class ResultHandler {
 						getRelationsById().put(ei.id, rRelation);
 					}
 				}
-				if (!rRelations.contains(rRelation))
-					rRelations.add(rRelation);
+				rRelations.add(rRelation);
 			}
 			getRelationColumns().put(colKey, rRelations);
 			getUnresolvedColumns().remove(colKey);


### PR DESCRIPTION
Hi Wolfgang,

I have a problem within the getRelations method of ResultHandler (see my commit). In the original version relations don't get added more than once. This breaks the table structure which I can access with the JcQueryResult.resultOf methods. The indices become wrong if the Lists returned by resultOf don't have the same length. In my use case I have an optional match like 
`MATCH (n:Text) OPTIONAL MATCH (n)-[r:hasAudio]->(a:Audio) return n, r, a;`
Some "Text" labelled nodes have optional relations of type "hasAudio" to "Audio" labelled nodes and I want NULL values for r and a if the relationship doesn't exist. 
Let's suppose I have Text nodes n1, n2, n3 and no relationship yet. The result without my commit will be:

in Neo4J (in Rows view):
n1, **null**, null
n2, **null**, null
n3, **null**, null

in JCypher with JcQueryResult.resultOf:
List<GrNode> for Text: n1, n2, n3
List<GrRelation> for hasAudio: **null**
List<GrNode> for Audio: null, null, null
Note that the list for Audio nodes does contain the expected three null entries.

I probably don't have the overview of all possible use cases but as far as I can see duplicate relations should be allowed at this level.

Thanks for looking into this!

Best,

Marco