### PR TITLE
support multiclause stored procedure statements and result columns of type array

### DIFF
--- a/src/main/java/iot/jcypher/domainquery/internal/Settings.java
+++ b/src/main/java/iot/jcypher/domainquery/internal/Settings.java
@@ -23,4 +23,12 @@ public class Settings {
 	public static boolean strict = true;
 	public static final PlannerStrategy plannerStrategy = PlannerStrategy.RULE;
 	public static boolean TEST_MODE = false;
+	
+	public static ThreadLocal<Boolean> writeRulePlanner = new ThreadLocal<Boolean>() {
+		@Override
+		protected Boolean initialValue() {
+			return Boolean.TRUE;
+		}
+	};
+
 }

--- a/src/main/java/iot/jcypher/query/result/util/JSONContentHandler.java
+++ b/src/main/java/iot/jcypher/query/result/util/JSONContentHandler.java
@@ -192,10 +192,7 @@ public class JSONContentHandler extends AContentHandler {
 	}
 	
 	private JsonValue getRestValue(JsonArray restArray, int colIdx) {
-		JsonValue obj = restArray.get(colIdx);
-		if (obj.getValueType() == ValueType.ARRAY && ((JsonArray)obj).size() > 0)
-			obj = ((JsonArray)obj).get(0);
-		return obj;
+		return restArray.get(colIdx);
 	}
 	
 	private JsonObject getRestObject(JsonArray restArray, int colIdx) {

--- a/src/main/java/iot/jcypher/query/writer/CypherWriter.java
+++ b/src/main/java/iot/jcypher/query/writer/CypherWriter.java
@@ -112,7 +112,7 @@ public class CypherWriter {
 	}
 	
 	public static void toCypherExpression(JcQuery query, WriterContext context) {
-		if (!DBVersion.Neo4j_Version.equals(dBVersion_21x)) {
+		if (!DBVersion.Neo4j_Version.equals(dBVersion_21x) && Settings.writeRulePlanner.get()) {
 			context.buffer.append("CYPHER planner=");
 			context.buffer.append(Settings.plannerStrategy.name().toLowerCase());
 			Pretty.writePreClauseSeparator(context, context.buffer);


### PR DESCRIPTION
Hi Wolfgang,

this pull request addresses two issues:
1) A Settings member to switch off the inclusion of the rule planner. The Neo4J rule planner doesn't support a stored procedure call to be mixed with other clauses. I tried to follow your style for concurrency sensitive settings here.
2) If the resultset column is of type array I need the full content of that array and not just the first field. So I simply removed the corresponding code. 
An example would be the query 
`match (n) return labels(n), count(n)`
which gives me a resultset with two columns. First column of type string array and second column of type int, counting the number of nodes grouped by (non overlapping) labelsets. So the first column is an array of node labels which I can then retrieve with a JcCollection.

Thanks for considering this pull request. 

Best,
Marco