### PR TITLE
Bugfix/handling 0 min hops

### DIFF
--- a/src/main/java/iot/jcypher/query/result/util/JSONContentHandler.java
+++ b/src/main/java/iot/jcypher/query/result/util/JSONContentHandler.java
@@ -292,7 +292,7 @@ public class JSONContentHandler extends AContentHandler {
 					ElementInfo ei = ElementInfo.nullElement();
 					return ei;
 				}
-				return null;
+				return ElementInfo.nullElement();
 			}
 
 			@Override

--- a/src/main/java/iot/jcypher/query/writer/CypherWriter.java
+++ b/src/main/java/iot/jcypher/query/writer/CypherWriter.java
@@ -1034,9 +1034,9 @@ public class CypherWriter {
 				}
 				
 				if (r.getMinHops() == 0 && r.getMaxHops() == -1) // hops unbound
-					context.buffer.append('*');
+					context.buffer.append("*0..");
 				else if (r.getMinHops() == 0) {
-					context.buffer.append("*..");
+					context.buffer.append("*0..");
 					context.buffer.append(r.getMaxHops());
 				} else if (r.getMaxHops() == -1) {
 					context.buffer.append('*');

--- a/src/test/java/test/OptionalHopsTest.java
+++ b/src/test/java/test/OptionalHopsTest.java
@@ -1,0 +1,129 @@
+package test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import iot.jcypher.database.IDBAccess;
+import iot.jcypher.graph.GrNode;
+import iot.jcypher.graph.GrRelation;
+import iot.jcypher.query.JcQuery;
+import iot.jcypher.query.JcQueryResult;
+import iot.jcypher.query.api.IClause;
+import iot.jcypher.query.factories.clause.CREATE;
+import iot.jcypher.query.factories.clause.MATCH;
+import iot.jcypher.query.factories.clause.RETURN;
+import iot.jcypher.query.result.JcError;
+import iot.jcypher.query.result.JcResultException;
+import iot.jcypher.query.values.JcNode;
+import iot.jcypher.query.values.JcRelation;
+import java.util.List;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class OptionalHopsTest extends AbstractTestSuite {
+    private static IDBAccess dbAccess;
+
+    @BeforeClass
+    public static void before() {
+        dbAccess = DBAccessSettings.createDBAccess();
+
+        List<JcError> errors = dbAccess.clearDatabase();
+        if (errors.size() > 0) {
+            printErrors(errors);
+            throw new JcResultException(errors);
+        }
+    }
+
+    @AfterClass
+    public static void after() {
+        if (dbAccess != null) {
+            dbAccess.close();
+            dbAccess = null;
+        }
+    }
+
+    @Test
+    public void testDBAccess_01() {
+        createDB_01();
+        queryDB_01();
+        return;
+    }
+
+    private void createDB_01() {
+
+        JcNode andreas = new JcNode("Andres");
+        JcNode adam = new JcNode("Adam");
+        JcNode joe = new JcNode("Joe");
+        JcNode c1 = new JcNode("c1");
+        JcNode c2 = new JcNode("c2");
+        JcNode c3 = new JcNode("c3");
+        JcNode n1 = new JcNode("notebook");
+
+        /*******************************/
+        JcQuery query = new JcQuery();
+        query.setClauses(new IClause[] {
+            CREATE.node(andreas).label("JcTestPerson")
+                .property("name").value("Andres")
+                .property("title").value("Developer"),
+            CREATE.node(adam).label("JcTestPerson")
+                .property("name").value("Adam")
+                .property("title").value("Developer"),
+            CREATE.node(joe).label("JcTestPerson")
+                .property("name").value("Joe")
+                .property("title").value("Manager"),
+            CREATE.node(c1).label("JcTestComputer")
+                .property("code").value("ABC123"),
+            CREATE.node(c2).label("JcTestComputer")
+                .property("code").value("ABC345"),
+            CREATE.node(c3).label("JcTestComputer")
+                .property("code").value("ABC678"),
+            CREATE.node(n1).label("JcTestNotebook")
+                .property("code").value("N123"),
+            CREATE.node(andreas).relation().out().type("POSSESS").node(c1),
+            CREATE.node(adam).relation().out().type("POSSESS").node(c2),
+            CREATE.node(joe).relation().out().type("POSSESS").node(c3),
+            CREATE.node(joe).relation().out().type("LEASE").node(n1),
+        });
+
+        JcQueryResult result = dbAccess.execute(query);
+        if (result.hasErrors())
+            printErrors(result);
+        assertFalse(result.hasErrors());
+
+        return;
+    }
+
+    private void queryDB_01() {
+        JcNode n0 = new JcNode("n0");
+        JcNode n1 = new JcNode("n1");
+        JcRelation r0 = new JcRelation("r");
+
+        /*******************************/
+        JcQuery query = new JcQuery();
+        query.setClauses(new IClause[] {
+            MATCH.node(n0).label("JcTestPerson")
+                .relation(r0).out().type("LEASE").minHops(0)
+                .node(n1),
+            RETURN.value(n0),
+            RETURN.value(r0),
+            RETURN.value(n1),
+        });
+
+        JcQueryResult result = dbAccess.execute(query);
+        if (result.hasErrors())
+            printErrors(result);
+
+        List<GrNode> n00 = result.resultOf(n0);
+        List<GrRelation> r00 = result.resultOf(r0);
+        List<GrNode> n11 = result.resultOf(n1);
+
+        // how *0 should work:
+        // https://graphaware.com/graphaware/2015/05/19/neo4j-cypher-variable-length-relationships-by-example.html
+        assertEquals(3, n00.size());
+        assertEquals(1, r00.size());
+        assertEquals(4, n11.size()); //this is all n0 nodes + all possible nodes from LEASE
+
+        return;
+    }
+}


### PR DESCRIPTION
It seems that jCypher has a bug when it comes to handle minHops(0) definition in query clauses when fetching object with related elements to it. For instance assuming we have following model:
    
```
    (n:JcTestPerson { name: 'Andres', title: 'Developer' })-[POSSESS]->(n:JcTestComputer { code: 'ABC123' })
    (n:JcTestPerson { name: 'Adam', title: 'Developer' })-[POSSESS]->(n:JcTestComputer { code: 'ABC345' })
    (n:JcTestPerson { name: 'Joe', title: 'Manager' })-[POSSESS]->(n:JcTestComputer { code: 'ABC678' })
                                                      `[LEASE]->(n:JcTestNotebook { code: 'N123' })
```
    
Then assuming we would like to fetch **all persons and if they do LEASE notebook fetch it along as well**, than I would expect to build following DSL query (based on https://graphaware.com/graphaware/2015/05/19/neo4j-cypher-variable-length-relationships-by-example.html):

```
            JcNode n0 = new JcNode("n0");
            JcNode n1 = new JcNode("n1");
            JcRelation r0 = new JcRelation("r");
    
        MATCH.node(n0).label("JcTestPerson")
                    .relation(r0).out().type("LEASE").minHops(0)
                    .node(n1),
                RETURN.value(n0),
                RETURN.value(r0),
                RETURN.value(n1),
```

   however such DSL ends up to be translated to cypher from point number 1 from  following list (assuming that max hops remain default = 1), and I would expect to translate it to the one like in point 2:

1. `MATCH (n0:JcTestPerson)-[r0:LEASE*..1]-(n1) RETURN n0,r0,n1` 
      -> does return only Joe and its leased notebook
    
```
+-----------------------------------------------------------------------------------------------------+
| n0                                       | r             | n1                                       |
+-----------------------------------------------------------------------------------------------------+
| Node[2]{name:"Joe",title:"Manager"}      | [:LEASE[3]{}] | Node[6]{code:"N123"}                     |
+-----------------------------------------------------------------------------------------------------+
```
   
2. `MATCH (n0:JcTestPerson)-[r0:LEASE*0..1]->(n1) RETURN n0,r0,n1`
-> does return all Person and the leased notebook.
```
+-----------------------------------------------------------------------------------------------------+
| n0                                       | r             | n1                                       |
+-----------------------------------------------------------------------------------------------------+
| Node[0]{name:"Andres",title:"Developer"} | []            | Node[0]{name:"Andres",title:"Developer"} |
| Node[1]{name:"Adam",title:"Developer"}   | []            | Node[1]{name:"Adam",title:"Developer"}   |
| Node[2]{name:"Joe",title:"Manager"}      | []            | Node[2]{name:"Joe",title:"Manager"}      |
| Node[2]{name:"Joe",title:"Manager"}      | [:LEASE[3]{}] | Node[6]{code:"N123"}                     |
+-----------------------------------------------------------------------------------------------------+
```




Had manully tested it with 
======== Neo4j 3.3.2 =====
======== Neo4j 3.4.1 =====

Following are raw cypher queries, just for testing it via neo4j browser.

```
CREATE (n:JcTestPerson { name: 'Andres', title: 'Developer' })
CREATE (n:JcTestPerson { name: 'Adam', title: 'Developer' })
CREATE (n:JcTestPerson { name: 'Joe', title: 'Manager' })

CREATE (n:JcTestComputer { code: 'ABC123' })
CREATE (n:JcTestComputer { code: 'ABC345' })
CREATE (n:JcTestComputer { code: 'ABC678' })

CREATE (n:JcTestNotebook { code: 'N123' })

MATCH (a:JcTestPerson),(b:JcTestComputer)
WHERE a.name = 'Andres' AND b.code = 'ABC123'
CREATE (a)-[r:POSSESS]->(b)
RETURN type(r)

MATCH (a:JcTestPerson),(b:JcTestComputer)
WHERE a.name = 'Adam' AND b.code = 'ABC345'
CREATE (a)-[r:POSSESS]->(b)
RETURN type(r)

MATCH (a:JcTestPerson),(b:JcTestComputer)
WHERE a.name = 'Joe' AND b.code = 'ABC678'
CREATE (a)-[r:POSSESS]->(b)
RETURN type(r)


MATCH (a:JcTestPerson),(b:JcTestNotebook)
WHERE a.name = 'Joe' AND b.code = 'N123'
CREATE (a)-[r:LEASE]->(b)
RETURN type(r)


match (n1:JcTestPerson)-[:LEASE*]-(n2) return n1,n2  -> does return only Joe and its leased notebook
match (n1:JcTestPerson)-[:LEASE*0]-(n2) return n1,n2  -> does return all Person, but no leased nodes
match (n1:JcTestPerson)-[:LEASE*0..]->(n2) return n1,n2 -> does return does return all Person and the leased notebook.
```